### PR TITLE
Implementing half of the remaining CHIP-8 Commands

### DIFF
--- a/include/commands.h
+++ b/include/commands.h
@@ -1,6 +1,8 @@
 #ifndef __COMMANDS_H__
 #define __COMMANDS_H__
 
+#include <vector>
+
 #include "const.h"
 #include "drawing.h"
 #include <stdint.h>
@@ -14,7 +16,7 @@ class Command
 public:
     virtual auto execute(
         uint8_t *memory, bool display[DISPLAY_HEIGHT][DISPLAY_WIDTH],
-        uint16_t *stack, uint8_t varRegisters[VARIABLE_REGISTERS_SIZE],
+        std::vector<uint16_t>& stack, uint8_t varRegisters[VARIABLE_REGISTERS_SIZE],
         uint12_struct *pc, uint16_t *ir) -> void = 0;
 };
 
@@ -24,13 +26,21 @@ class ClearScreenCommand : public Command
 public:
     auto execute(
         uint8_t *memory, bool display[DISPLAY_HEIGHT][DISPLAY_WIDTH],
-        uint16_t *stack, uint8_t varRegisters[VARIABLE_REGISTERS_SIZE],
+        std::vector<uint16_t>& stack, uint8_t varRegisters[VARIABLE_REGISTERS_SIZE],
+        uint12_struct *pc, uint16_t *ir) -> void;
+};
+
+class PopSubRoutine : public Command
+{
+public:
+    auto execute(
+        uint8_t *memory, bool display[DISPLAY_HEIGHT][DISPLAY_WIDTH],
+        std::vector<uint16_t>& stack, uint8_t varRegisters[VARIABLE_REGISTERS_SIZE],
         uint12_struct *pc, uint16_t *ir) -> void;
 };
 
 class JumpCommand : public Command
 {
-
 private:
     uint12_struct address;
 
@@ -38,13 +48,26 @@ public:
     JumpCommand(uint12_struct address);
     auto execute(
         uint8_t *memory, bool display[DISPLAY_HEIGHT][DISPLAY_WIDTH],
-        uint16_t *stack, uint8_t varRegisters[VARIABLE_REGISTERS_SIZE],
+        std::vector<uint16_t>& stack, uint8_t varRegisters[VARIABLE_REGISTERS_SIZE],
+        uint12_struct *pc, uint16_t *ir) -> void;
+};
+
+class SubRoutines : public Command
+{
+private:
+    uint12_struct address;
+
+public:
+    SubRoutines(uint12_struct subroutine_address);
+
+    auto execute(
+        uint8_t *memory, bool display[DISPLAY_HEIGHT][DISPLAY_WIDTH],
+        std::vector<uint16_t>& stack, uint8_t varRegisters[VARIABLE_REGISTERS_SIZE],
         uint12_struct *pc, uint16_t *ir) -> void;
 };
 
 class SetRegister : public Command
 {
-
 private:
     uint8_t selected_register;
     uint8_t value_to_set;
@@ -53,7 +76,7 @@ public:
     SetRegister(uint8_t selected_register, uint8_t value_to_set);
     auto execute(
         uint8_t *memory, bool display[DISPLAY_HEIGHT][DISPLAY_WIDTH],
-        uint16_t *stack, uint8_t varRegisters[VARIABLE_REGISTERS_SIZE],
+        std::vector<uint16_t>& stack, uint8_t varRegisters[VARIABLE_REGISTERS_SIZE],
         uint12_struct *pc, uint16_t *ir) -> void;
 };
 
@@ -67,7 +90,7 @@ public:
     AddValueToRegister(uint8_t selected_register, uint8_t value_to_add);
     auto execute(
         uint8_t *memory, bool display[DISPLAY_HEIGHT][DISPLAY_WIDTH],
-        uint16_t *stack, uint8_t varRegisters[VARIABLE_REGISTERS_SIZE],
+        std::vector<uint16_t>& stack, uint8_t varRegisters[VARIABLE_REGISTERS_SIZE],
         uint12_struct *pc, uint16_t *ir) -> void;
 };
 
@@ -80,7 +103,7 @@ public:
     SetIndexRegister(uint12_struct i_register_address);
     auto execute(
         uint8_t *memory, bool display[DISPLAY_HEIGHT][DISPLAY_WIDTH],
-        uint16_t *stack, uint8_t varRegisters[VARIABLE_REGISTERS_SIZE],
+        std::vector<uint16_t>& stack, uint8_t varRegisters[VARIABLE_REGISTERS_SIZE],
         uint12_struct *pc, uint16_t *ir) -> void;
 };
 
@@ -95,7 +118,7 @@ public:
     DisplayDraw(uint8_t x, uint8_t y, uint8_t height);
     auto execute(
         uint8_t *memory, bool display[DISPLAY_HEIGHT][DISPLAY_WIDTH],
-        uint16_t *stack, uint8_t varRegisters[VARIABLE_REGISTERS_SIZE],
+        std::vector<uint16_t>& stack, uint8_t varRegisters[VARIABLE_REGISTERS_SIZE],
         uint12_struct *pc, uint16_t *ir) -> void;
 };
 
@@ -108,7 +131,7 @@ public:
     InvalidCommand(uint16_t instruction);
     auto execute(
         uint8_t *memory, bool display[DISPLAY_HEIGHT][DISPLAY_WIDTH],
-        uint16_t *stack, uint8_t varRegisters[VARIABLE_REGISTERS_SIZE],
+        std::vector<uint16_t>& stack, uint8_t varRegisters[VARIABLE_REGISTERS_SIZE],
         uint12_struct *pc, uint16_t *ir) -> void;
 };
 

--- a/include/commands.h
+++ b/include/commands.h
@@ -66,6 +66,58 @@ public:
         uint12_struct *pc, uint16_t *ir) -> void;
 };
 
+class SkipXEqVar : public Command
+{
+private:
+    uint8_t register_x;
+    uint8_t conditional_val;
+public:
+    SkipXEqVar(uint8_t register_x, uint8_t conditional_val);
+    auto execute(
+    uint8_t *memory, bool display[DISPLAY_HEIGHT][DISPLAY_WIDTH],
+    std::vector<uint16_t>& stack, uint8_t varRegisters[VARIABLE_REGISTERS_SIZE],
+    uint12_struct *pc, uint16_t *ir) -> void;
+};
+
+class SkipXNotEquVar : public Command
+{
+private:
+    uint8_t register_x;
+    uint8_t conditional_val;
+public:
+    SkipXNotEquVar(uint8_t register_x, uint8_t conditional_val);
+    auto execute(
+    uint8_t *memory, bool display[DISPLAY_HEIGHT][DISPLAY_WIDTH],
+    std::vector<uint16_t>& stack, uint8_t varRegisters[VARIABLE_REGISTERS_SIZE],
+    uint12_struct *pc, uint16_t *ir) -> void;
+};
+
+class SkipXEquY : public Command
+{
+private:
+    uint8_t register_x;
+    uint8_t register_y;
+public:
+    SkipXEquY(uint8_t register_x, uint8_t register_y);
+    auto execute(
+    uint8_t *memory, bool display[DISPLAY_HEIGHT][DISPLAY_WIDTH],
+    std::vector<uint16_t>& stack, uint8_t varRegisters[VARIABLE_REGISTERS_SIZE],
+    uint12_struct *pc, uint16_t *ir) -> void;
+};
+
+class SkipXNotEquY : public Command
+{
+private:
+    uint8_t register_x;
+    uint8_t register_y;
+public:
+    SkipXNotEquY(uint8_t register_x, uint8_t register_y);
+    auto execute(
+    uint8_t *memory, bool display[DISPLAY_HEIGHT][DISPLAY_WIDTH],
+    std::vector<uint16_t>& stack, uint8_t varRegisters[VARIABLE_REGISTERS_SIZE],
+    uint12_struct *pc, uint16_t *ir) -> void;
+};
+
 class SetRegister : public Command
 {
 private:

--- a/include/commands.h
+++ b/include/commands.h
@@ -146,6 +146,20 @@ public:
         uint12_struct *pc, uint16_t *ir) -> void;
 };
 
+class LogicAndArithmetic : public Command
+{
+private:
+    uint8_t operation;
+    uint8_t x_register;
+    uint8_t y_register;
+public:
+    LogicAndArithmetic(uint8_t x_register, uint8_t y_register, uint8_t operation);
+    auto execute(
+        uint8_t *memory, bool display[DISPLAY_HEIGHT][DISPLAY_WIDTH],
+        std::vector<uint16_t>& stack, uint8_t varRegisters[VARIABLE_REGISTERS_SIZE],
+        uint12_struct *pc, uint16_t *ir) -> void;
+};
+
 class SetIndexRegister : public Command
 {
 private:

--- a/include/main.h
+++ b/include/main.h
@@ -3,7 +3,8 @@
 
 #include <thread>
 #include <memory>
-#include <fstream> 
+#include <fstream>
+#include <vector> 
 
 // internal files
 #include "const.h"

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -102,8 +102,6 @@ auto SkipXNotEquY::execute(
         pc->bits += 2;
 }
 
-
-
 SetRegister::SetRegister(uint8_t selected_register, uint8_t value_to_set)
 {
     this->selected_register = selected_register;
@@ -116,6 +114,86 @@ auto SetRegister::execute(
 {
     // selected_register should be 4 bits max
     varRegister[selected_register] = value_to_set;
+}
+
+LogicAndArithmetic::LogicAndArithmetic(uint8_t x_register, uint8_t y_register, uint8_t operation)
+{
+    this->x_register = x_register;
+    this->y_register = y_register;
+    this->operation = operation;
+}
+auto LogicAndArithmetic::execute(
+    uint8_t *memory, bool display[DISPLAY_HEIGHT][DISPLAY_WIDTH],
+    std::vector<uint16_t>& stack, uint8_t varRegister[VARIABLE_REGISTERS_SIZE],
+    uint12_struct *pc, uint16_t *ir) -> void
+{
+
+    switch (this->operation)
+    {
+    case 0x0:    // Set X to Y
+        varRegister[x_register] = varRegister[y_register];
+        break;
+    case 0x1:
+        varRegister[x_register] = varRegister[x_register] | varRegister[y_register];
+        break;
+    case 0x2:
+        varRegister[x_register] = varRegister[x_register] & varRegister[y_register];
+        break;
+    case 0x3:
+        varRegister[x_register] = varRegister[x_register] ^ varRegister[y_register];
+        break;
+    case 0x4:
+        if(varRegister[x_register] > 255 - varRegister[y_register])
+        {
+            varRegister[0xF] = 1;
+        }
+        else
+        {
+            varRegister[0xF] = 0;
+        }
+        varRegister[x_register] = varRegister[x_register] + varRegister[y_register];
+        break;
+    case 0x5:
+        if(varRegister[x_register] <= varRegister[y_register])
+        {
+            varRegister[0XF] = 1;
+        }
+        else
+        {
+            varRegister[0xF] = 0;
+        }
+        varRegister[x_register] = varRegister[x_register] - varRegister[y_register];
+        break;
+    case 0x6:
+    {
+        varRegister[x_register] = varRegister[y_register];
+        uint8_t carry = varRegister[x_register] & 0x01; // bit that is shifted out is saved for carry flag
+        varRegister[x_register] = varRegister[x_register] >> 1;
+        varRegister[0xF] = carry;
+        break;
+    }
+    case 0x7:
+        if(varRegister[y_register] <= varRegister[x_register])
+        {
+            varRegister[0XF] = 1;
+        }
+        else
+        {
+            varRegister[0xF] = 0;
+        }
+        varRegister[x_register] = varRegister[y_register] - varRegister[x_register];
+        break;
+    case 0xE:
+    {
+        varRegister[x_register] = varRegister[y_register];
+        uint8_t carry = (varRegister[x_register] & 0x80) >> 7; // bit that is shifted out is saved for carry flag
+        varRegister[x_register] = varRegister[x_register] << 1;
+        varRegister[0xF] = carry;
+        break;
+    }
+    default:
+        break;
+    }
 }
 
 AddValueToRegister::AddValueToRegister(uint8_t selected_register, uint8_t value_to_add)

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -46,6 +46,64 @@ auto SubRoutines::execute(
     pc->bits = this->address.bits;
 }
 
+SkipXEqVar::SkipXEqVar(uint8_t register_x, uint8_t conditional_val)
+{
+    this->register_x = register_x;
+    this->conditional_val = conditional_val;
+}
+auto SkipXEqVar::execute(
+    uint8_t *memory, bool display[DISPLAY_HEIGHT][DISPLAY_WIDTH],
+    std::vector<uint16_t>& stack, uint8_t varRegister[VARIABLE_REGISTERS_SIZE],
+    uint12_struct *pc, uint16_t *ir) -> void
+{
+    if(varRegister[this->register_x] == conditional_val)
+        pc->bits += 2;
+}
+
+SkipXNotEquVar::SkipXNotEquVar(uint8_t register_x, uint8_t conditional_val)
+{
+    this->register_x = register_x;
+    this->conditional_val = conditional_val;
+}
+auto SkipXNotEquVar::execute(
+    uint8_t *memory, bool display[DISPLAY_HEIGHT][DISPLAY_WIDTH],
+    std::vector<uint16_t>& stack, uint8_t varRegister[VARIABLE_REGISTERS_SIZE],
+    uint12_struct *pc, uint16_t *ir) -> void
+{
+    if(varRegister[this->register_x] != conditional_val)
+        pc->bits += 2;
+}
+
+SkipXEquY::SkipXEquY(uint8_t register_x, uint8_t register_y)
+{
+    this->register_x = register_x;
+    this->register_y = register_y;
+}
+auto SkipXEquY::execute(
+    uint8_t *memory, bool display[DISPLAY_HEIGHT][DISPLAY_WIDTH],
+    std::vector<uint16_t>& stack, uint8_t varRegister[VARIABLE_REGISTERS_SIZE],
+    uint12_struct *pc, uint16_t *ir) -> void
+{
+    if(varRegister[this->register_x] == varRegister[this->register_y])
+        pc->bits += 2;
+}
+
+SkipXNotEquY::SkipXNotEquY(uint8_t register_x, uint8_t register_y)
+{
+    this->register_x = register_x;
+    this->register_y = register_y;
+}
+auto SkipXNotEquY::execute(
+    uint8_t *memory, bool display[DISPLAY_HEIGHT][DISPLAY_WIDTH],
+    std::vector<uint16_t>& stack, uint8_t varRegister[VARIABLE_REGISTERS_SIZE],
+    uint12_struct *pc, uint16_t *ir) -> void
+{
+    if(varRegister[this->register_x] != varRegister[this->register_y])
+        pc->bits += 2;
+}
+
+
+
 SetRegister::SetRegister(uint8_t selected_register, uint8_t value_to_set)
 {
     this->selected_register = selected_register;

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -4,12 +4,21 @@ using namespace std; // TODO: Remove once program is complete, here for testing 
 
 auto ClearScreenCommand::execute(
     uint8_t *memory, bool display[DISPLAY_HEIGHT][DISPLAY_WIDTH],
-    uint16_t *stack, uint8_t varRegister[VARIABLE_REGISTERS_SIZE],
+    std::vector<uint16_t>& stack, uint8_t varRegister[VARIABLE_REGISTERS_SIZE],
     uint12_struct *pc, uint16_t *ir) -> void
 {
     for (int i = 0; i < DISPLAY_HEIGHT; i++)
         for (int j = 0; j < DISPLAY_WIDTH; j++)
             display[i][j] = false;
+}
+
+auto PopSubRoutine::execute(
+    uint8_t *memory, bool display[DISPLAY_HEIGHT][DISPLAY_WIDTH],
+    std::vector<uint16_t>& stack, uint8_t varRegister[VARIABLE_REGISTERS_SIZE],
+    uint12_struct *pc, uint16_t *ir) -> void
+{
+    pc->bits = stack.back();
+    stack.pop_back();
 }
 
 JumpCommand::JumpCommand(uint12_struct address)
@@ -18,9 +27,22 @@ JumpCommand::JumpCommand(uint12_struct address)
 }
 auto JumpCommand::execute(
     uint8_t *memory, bool display[DISPLAY_HEIGHT][DISPLAY_WIDTH],
-    uint16_t *stack, uint8_t varRegister[VARIABLE_REGISTERS_SIZE],
+    std::vector<uint16_t>& stack, uint8_t varRegister[VARIABLE_REGISTERS_SIZE],
     uint12_struct *pc, uint16_t *ir) -> void
 {
+    pc->bits = this->address.bits;
+}
+
+SubRoutines::SubRoutines(uint12_struct subroutine_address)
+{
+    this->address = subroutine_address;
+}
+auto SubRoutines::execute(
+    uint8_t *memory, bool display[DISPLAY_HEIGHT][DISPLAY_WIDTH],
+    std::vector<uint16_t>& stack, uint8_t varRegister[VARIABLE_REGISTERS_SIZE],
+    uint12_struct *pc, uint16_t *ir) -> void
+{
+    stack.push_back(pc->bits);
     pc->bits = this->address.bits;
 }
 
@@ -31,7 +53,7 @@ SetRegister::SetRegister(uint8_t selected_register, uint8_t value_to_set)
 }
 auto SetRegister::execute(
     uint8_t *memory, bool display[DISPLAY_HEIGHT][DISPLAY_WIDTH],
-    uint16_t *stack, uint8_t varRegister[VARIABLE_REGISTERS_SIZE],
+    std::vector<uint16_t>& stack, uint8_t varRegister[VARIABLE_REGISTERS_SIZE],
     uint12_struct *pc, uint16_t *ir) -> void
 {
     // selected_register should be 4 bits max
@@ -45,7 +67,7 @@ AddValueToRegister::AddValueToRegister(uint8_t selected_register, uint8_t value_
 }
 auto AddValueToRegister::execute(
     uint8_t *memory, bool display[DISPLAY_HEIGHT][DISPLAY_WIDTH],
-    uint16_t *stack, uint8_t varRegister[VARIABLE_REGISTERS_SIZE],
+    std::vector<uint16_t>& stack, uint8_t varRegister[VARIABLE_REGISTERS_SIZE],
     uint12_struct *pc, uint16_t *ir) -> void
 {
     varRegister[selected_register] += value_to_add;
@@ -57,7 +79,7 @@ SetIndexRegister::SetIndexRegister(uint12_struct i_register_address)
 }
 auto SetIndexRegister::execute(
     uint8_t *memory, bool display[DISPLAY_HEIGHT][DISPLAY_WIDTH],
-    uint16_t *stack, uint8_t varRegister[VARIABLE_REGISTERS_SIZE],
+    std::vector<uint16_t>& stack, uint8_t varRegister[VARIABLE_REGISTERS_SIZE],
     uint12_struct *pc, uint16_t *ir) -> void
 {
     *ir = this->i_register_address.bits;
@@ -71,7 +93,7 @@ DisplayDraw::DisplayDraw(uint8_t x, uint8_t y, uint8_t height)
 }
 auto DisplayDraw::execute(
     uint8_t *memory, bool display[DISPLAY_HEIGHT][DISPLAY_WIDTH],
-    uint16_t *stack, uint8_t varRegister[VARIABLE_REGISTERS_SIZE],
+    std::vector<uint16_t>& stack, uint8_t varRegister[VARIABLE_REGISTERS_SIZE],
     uint12_struct *pc, uint16_t *ir) -> void
 {
     // modulo with screen demensions because values can wrap around
@@ -112,7 +134,7 @@ InvalidCommand::InvalidCommand(uint16_t instruction)
 }
 auto InvalidCommand::execute(
     uint8_t *memory, bool display[DISPLAY_HEIGHT][DISPLAY_WIDTH],
-    uint16_t *stack, uint8_t varRegister[VARIABLE_REGISTERS_SIZE],
+    std::vector<uint16_t>& stack, uint8_t varRegister[VARIABLE_REGISTERS_SIZE],
     uint12_struct *pc, uint16_t *ir) -> void
 {
 

--- a/src/instruction_loop/decode.cpp
+++ b/src/instruction_loop/decode.cpp
@@ -1,62 +1,88 @@
 #include "../../include/decode.h"
 
-auto decode(uint16_t instruction) -> std::unique_ptr<Command> {
+auto decode(uint16_t instruction) -> std::unique_ptr<Command>
+{
 
     std::unique_ptr<Command> command;
 
-    switch(instruction) {
-        // instruction decoding
-        case 0x00E0:
-            command = std::make_unique<ClearScreenCommand>();
-            break;
-        case 0x00EE:
-            command = std::make_unique<PopSubRoutine>();
-            break;
-        case 0x1000 ... 0x1FFF: 
-        {
-            uint12_struct address;
-            address.bits = instruction; // only 3 least significant bytes saved, last byte is removed
-            command = std::make_unique<JumpCommand>(address);
-            break;
-        }
-        case 0x2000 ... 0x2FFF:
-        {
-            uint12_struct address;
-            address.bits = instruction; // only 3 least significant bytes saved, last byte is removed
-            command = std::make_unique<SubRoutines>(address);
-            break;
-        }
-        case 0x6000 ... 0x6FFF:
-        {
-            uint8_t  selected_register = (instruction & 0x0F00) >> 8; // first 4 bits after the 6
-            uint8_t  value = instruction; // last 8 bits (since rest will be cut off)
-            command = std::make_unique<SetRegister>(selected_register, value);
-            break;
-        }
-        case 0x7000 ... 0x7FFF:
-        {
-            uint8_t  selected_register = (instruction & 0x0F00) >> 8; // first 4 bits after the 7
-            uint8_t  value = instruction; // last 8 bits (since rest will be cut off)
-            command = std::make_unique<AddValueToRegister>(selected_register, value);
-            break;
-        }
-        case 0xA000 ... 0xAFFF:
-        {
-           uint12_struct i_register_address;
-           i_register_address.bits = instruction; 
-           command = std::make_unique<SetIndexRegister>(i_register_address);
-           break;
-        }
-        case 0xD000 ... 0xDFFF:
-        {
-            uint8_t x = (instruction & 0x0F00) >> 8; // first 4 bits after D is register to get x
-            uint8_t y = (instruction & 0x00F0) >> 4; // next 4 bits is register to get y
-            uint8_t height = (instruction & 0x000F); // last 4 bits is height
-            command = std::make_unique<DisplayDraw>(x, y, height);
-            break;
-        }
-        default:
-            command = std::make_unique<InvalidCommand>(instruction);
+    switch (instruction)
+    {
+    // instruction decoding
+    case 0x00E0:
+        command = std::make_unique<ClearScreenCommand>();
+        break;
+    case 0x00EE:
+        command = std::make_unique<PopSubRoutine>();
+        break;
+    case 0x1000 ... 0x1FFF:
+    {
+        uint12_struct address;
+        address.bits = instruction; // only 3 least significant bytes saved, last byte is removed
+        command = std::make_unique<JumpCommand>(address);
+        break;
+    }
+    case 0x2000 ... 0x2FFF:
+    {
+        uint12_struct address;
+        address.bits = instruction; // only 3 least significant bytes saved, last byte is removed
+        command = std::make_unique<SubRoutines>(address);
+        break;
+    }
+    case 0x3000 ... 0x3FFF: // Skip if X equal to Conditional
+    {
+        uint8_t register_x = (instruction & 0x0F00) >> 8;
+        uint8_t condtional_val = instruction; // cuts off first 8 bits, leaving last 8
+        command = std::make_unique<SkipXEqVar>(register_x, condtional_val);
+    }
+    case 0x4000 ... 0x4FFF:
+    {
+        uint8_t register_x = (instruction & 0x0F00) >> 8;
+        uint8_t condtional_val = instruction; // cuts off first 8 bits, leaving last 8
+        command = std::make_unique<SkipXNotEquVar>(register_x, condtional_val);
+    }
+    case 0x5000 ... 0x5FFF:
+    {
+        uint8_t register_x = (instruction & 0x0F00) >> 8;
+        uint8_t register_y = (instruction & 0x00F0) >> 4;
+        command = std::make_unique<SkipXEquY>(register_x, register_y);
+    }
+    case 0x6000 ... 0x6FFF:
+    {
+        uint8_t selected_register = (instruction & 0x0F00) >> 8; // first 4 bits after the 6
+        uint8_t value = instruction;                             // last 8 bits (since rest will be cut off)
+        command = std::make_unique<SetRegister>(selected_register, value);
+        break;
+    }
+    case 0x7000 ... 0x7FFF:
+    {
+        uint8_t selected_register = (instruction & 0x0F00) >> 8; // first 4 bits after the 7
+        uint8_t value = instruction;                             // last 8 bits (since rest will be cut off)
+        command = std::make_unique<AddValueToRegister>(selected_register, value);
+        break;
+    }
+    case 0x9000 ... 0x9FFF:
+    {
+        uint8_t register_x = (instruction & 0x0F00) >> 8;
+        uint8_t register_y = (instruction & 0x00F0) >> 4;
+        command = std::make_unique<SkipXNotEquY>(register_x, register_y);
+    }
+    case 0xA000 ... 0xAFFF:
+    {
+        uint12_struct i_register_address;
+        i_register_address.bits = instruction;
+        command = std::make_unique<SetIndexRegister>(i_register_address);
+        break;
+    }
+    case 0xD000 ... 0xDFFF:
+    {
+        uint8_t x = (instruction & 0x0F00) >> 8; // first 4 bits after D is register to get x
+        uint8_t y = (instruction & 0x00F0) >> 4; // next 4 bits is register to get y
+        uint8_t height = (instruction & 0x000F); // last 4 bits is height
+        command = std::make_unique<DisplayDraw>(x, y, height);
+        break;
+    }
+    default:
+        command = std::make_unique<InvalidCommand>(instruction);
     }
 
     return command;

--- a/src/instruction_loop/decode.cpp
+++ b/src/instruction_loop/decode.cpp
@@ -33,18 +33,21 @@ auto decode(uint16_t instruction) -> std::unique_ptr<Command>
         uint8_t register_x = (instruction & 0x0F00) >> 8;
         uint8_t condtional_val = instruction; // cuts off first 8 bits, leaving last 8
         command = std::make_unique<SkipXEqVar>(register_x, condtional_val);
+        break;
     }
     case 0x4000 ... 0x4FFF:
     {
         uint8_t register_x = (instruction & 0x0F00) >> 8;
         uint8_t condtional_val = instruction; // cuts off first 8 bits, leaving last 8
         command = std::make_unique<SkipXNotEquVar>(register_x, condtional_val);
+        break;
     }
     case 0x5000 ... 0x5FFF:
     {
         uint8_t register_x = (instruction & 0x0F00) >> 8;
         uint8_t register_y = (instruction & 0x00F0) >> 4;
         command = std::make_unique<SkipXEquY>(register_x, register_y);
+        break;
     }
     case 0x6000 ... 0x6FFF:
     {
@@ -60,11 +63,20 @@ auto decode(uint16_t instruction) -> std::unique_ptr<Command>
         command = std::make_unique<AddValueToRegister>(selected_register, value);
         break;
     }
+    case 0x8000 ... 0x8FFF:
+    {
+        uint8_t x_register = instruction & 0x0F00;
+        uint8_t y_register = instruction & 0x00F0;
+        uint8_t operation = instruction & 0x000F;
+        command = std::make_unique<LogicAndArithmetic>(x_register, y_register, operation);
+        break;
+    }
     case 0x9000 ... 0x9FFF:
     {
         uint8_t register_x = (instruction & 0x0F00) >> 8;
         uint8_t register_y = (instruction & 0x00F0) >> 4;
         command = std::make_unique<SkipXNotEquY>(register_x, register_y);
+        break;
     }
     case 0xA000 ... 0xAFFF:
     {

--- a/src/instruction_loop/decode.cpp
+++ b/src/instruction_loop/decode.cpp
@@ -9,11 +9,21 @@ auto decode(uint16_t instruction) -> std::unique_ptr<Command> {
         case 0x00E0:
             command = std::make_unique<ClearScreenCommand>();
             break;
+        case 0x00EE:
+            command = std::make_unique<PopSubRoutine>();
+            break;
         case 0x1000 ... 0x1FFF: 
         {
             uint12_struct address;
             address.bits = instruction; // only 3 least significant bytes saved, last byte is removed
             command = std::make_unique<JumpCommand>(address);
+            break;
+        }
+        case 0x2000 ... 0x2FFF:
+        {
+            uint12_struct address;
+            address.bits = instruction; // only 3 least significant bytes saved, last byte is removed
+            command = std::make_unique<SubRoutines>(address);
             break;
         }
         case 0x6000 ... 0x6FFF:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,7 +7,7 @@ int main(int argc, char* argv[])
     bool Display[DISPLAY_HEIGHT][DISPLAY_WIDTH];    // Display
     uint8_t fontData[FONT_DATA_SIZE] = FONT_DATA;   // Font
     initializeFontInMemory(Memory, fontData);
-    uint16_t Stack[STACK_SIZE];                     // Stack
+    std::vector<uint16_t> Stack;                    // Stack (usually limited to 16, unlimited here)
     uint8_t DelayTimer = 255;                       // Delay Timer
     uint8_t SoundTimer = 255;                       // Sound Timer
     bool delayTimerOnSwitch = true;                 // bool that stops delay timer


### PR DESCRIPTION
Remaining Commands not already implemented in the IBM test story:
- [x]     00EE and 2NNN: Subroutines
- [x]     3XNN, 4XNN, 5XY0 and 9XY0: Skip
- [x]     Logical and arithmetic instructions
- [x]         8XY0: Set
- [x]         8XY1: Binary OR
- [x]         8XY2: Binary AND
- [x]         8XY3: Logical XOR
- [x]         8XY4: Add