### PR TITLE
Implementing the remaining CHIP-8 commands

### DIFF
--- a/include/commands.h
+++ b/include/commands.h
@@ -6,6 +6,7 @@
 #include "const.h"
 #include "drawing.h"
 #include <stdint.h>
+#include <cstdlib>
 
 // testing and debugging
 #define UNIMPLEMENTED_COMMAND_DEBUG_CALL std::cout << "UNIMPLEMENTED COMMAND CALLED" << std::endl;
@@ -167,6 +168,31 @@ private:
 
 public:
     SetIndexRegister(uint12_struct i_register_address);
+    auto execute(
+        uint8_t *memory, bool display[DISPLAY_HEIGHT][DISPLAY_WIDTH],
+        std::vector<uint16_t>& stack, uint8_t varRegisters[VARIABLE_REGISTERS_SIZE],
+        uint12_struct *pc, uint16_t *ir) -> void;
+};
+
+class JumpWithOffset : public Command
+{
+private:
+    uint12_struct address;
+public:
+    JumpWithOffset(uint12_struct address);
+    auto execute(
+        uint8_t *memory, bool display[DISPLAY_HEIGHT][DISPLAY_WIDTH],
+        std::vector<uint16_t>& stack, uint8_t varRegisters[VARIABLE_REGISTERS_SIZE],
+        uint12_struct *pc, uint16_t *ir) -> void;
+};
+
+class RandomNumber : public Command
+{
+private:
+    uint8_t operand;
+    uint8_t x_register;
+public:
+    RandomNumber(uint8_t operand, uint8_t x_register);
     auto execute(
         uint8_t *memory, bool display[DISPLAY_HEIGHT][DISPLAY_WIDTH],
         std::vector<uint16_t>& stack, uint8_t varRegisters[VARIABLE_REGISTERS_SIZE],

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -221,6 +221,31 @@ auto SetIndexRegister::execute(
     *ir = this->i_register_address.bits;
 }
 
+JumpWithOffset::JumpWithOffset(uint12_struct instruction) {
+    this->address = instruction;
+}
+auto JumpWithOffset::execute(
+    uint8_t *memory, bool display[DISPLAY_HEIGHT][DISPLAY_WIDTH],
+    std::vector<uint16_t>& stack, uint8_t varRegister[VARIABLE_REGISTERS_SIZE],
+    uint12_struct *pc, uint16_t *ir) -> void
+{
+    pc->bits = this->address.bits + varRegister[0];
+}
+
+RandomNumber::RandomNumber(uint8_t operand, uint8_t x_register) {
+    this->operand = operand;
+    this->x_register = x_register;
+}
+auto RandomNumber::execute(
+    uint8_t *memory, bool display[DISPLAY_HEIGHT][DISPLAY_WIDTH],
+    std::vector<uint16_t>& stack, uint8_t varRegister[VARIABLE_REGISTERS_SIZE],
+    uint12_struct *pc, uint16_t *ir) -> void
+{
+    uint8_t max = 0XFF;
+    uint8_t rand_num = (rand() % (max + 1));
+    varRegister[this->x_register] = rand_num & this->operand;
+}
+
 DisplayDraw::DisplayDraw(uint8_t x, uint8_t y, uint8_t height)
 {
     this->register_for_x_coordinate = x;

--- a/src/instruction_loop/decode.cpp
+++ b/src/instruction_loop/decode.cpp
@@ -85,6 +85,20 @@ auto decode(uint16_t instruction) -> std::unique_ptr<Command>
         command = std::make_unique<SetIndexRegister>(i_register_address);
         break;
     }
+    case 0xB000 ... 0xBFFF:
+    {
+        uint12_struct address;
+        address.bits = instruction; // 3 least significant bytes saved, last byte dropped
+        command = std::make_unique<JumpWithOffset>(address);
+        break;
+    }
+    case 0xC000 ... 0xCFFF:
+    {
+        uint8_t operand = instruction & 0xFF;
+        uint8_t x_register = (instruction & 0x0F00) >> 8;
+        command = std::make_unique<RandomNumber>(operand, x_register);
+        break;
+    }
     case 0xD000 ... 0xDFFF:
     {
         uint8_t x = (instruction & 0x0F00) >> 8; // first 4 bits after D is register to get x


### PR DESCRIPTION
Remaining commands:

- [x] BNNN: Jump with offset
- [x] CXNN: Random
- [ ] DXYN: Display
- [ ] EX9E and EXA1: Skip if key
- [ ] FX07, FX15 and FX18: Timers
- [ ] FX1E: Add to index
- [ ] FX0A: Get key
- [ ] FX29: Font character
- [ ] FX33: Binary-coded decimal conversion
- [ ] FX55 and FX65: Store and load memory